### PR TITLE
Améliorer le script phpver.sh pour portabilité et sécurité

### DIFF
--- a/phpver.sh
+++ b/phpver.sh
@@ -1,59 +1,177 @@
 #!/bin/bash
 
-# Config
+# Configuration et commentaires (FR)
+# Ce script a été modifié pour améliorer :
+#  - la portabilité (fonction mktemp compatible Linux/macOS/BSD),
+#  - la robustesse (set -euo pipefail, IFS restreint),
+#  - l'ergonomie (acceptation de 7.4 ou 74, options CLI --dry-run et -v/--version),
+#  - la sécurité opérationnelle (backup horodaté de l'ancien .htaccess, écriture atomique),
+#  - la sûreté au démarrage PHP (php.ini généré avec extensions commentées par défaut).
+#
+# Les sections ci-dessous sont commentées pour expliquer pourquoi chaque changement
+# a été apporté et comment l'adapter à différents environnements d'hébergement.
+set -euo pipefail
+IFS=$'\n\t'
 
 PWD=$(pwd)
 TXT_ERROR="[\e[0;31mERROR\e[0;0m]"
 TXT_OK="[\e[0;32mOK\e[0;0m]"
 TXT_INFO="[\e[0;33mINFO\e[0;0m]"
 
-# Demande de la version de PHP
-echo -e $TXT_INFO "Sélectionnez la version de PHP en format suivant (Pour les versions 5.2 jusqu'à la 8.2 | EXEMPLE : 74 pour PHP 7.4) : "
-read -r PHP_VERSION
+# Options par défaut
+DRY_RUN=0
+CLI_VERSION=""
+SHOW_HELP=0
 
-# Check si la version est ok
-if [[ ! $PHP_VERSION =~ ^(52|53|54|55|56|70|71|72|73|74|75|76|77|78|79|80|81|82|83)$ ]]; then
-    echo -e "$TXT_ERROR La version de PHP saisie '$PHP_VERSION' n'est pas correct. Veuillez entrer une version entre 52 et 83."
-    exit 1
+print_help() {
+    cat <<EOF
+Usage: $0 [options]
+
+Options:
+  -n, --dry-run       Afficher les actions sans écrire de fichiers
+  -v, --version <ver> Spécifier la version PHP (ex: 74) en ligne de commande
+  -h, --help          Afficher cette aide
+
+Si aucune version n'est fournie via -v/--version, le script demandera une saisie interactive.
+EOF
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -n|--dry-run)
+                DRY_RUN=1; shift ;;
+            -v|--version)
+                CLI_VERSION="$2"; shift 2 ;;
+            -h|--help)
+                SHOW_HELP=1; shift ;;
+            --)
+                shift; break ;;
+            -*)
+                echo "Unknown option: $1"; exit 1 ;;
+            *)
+                break ;;
+        esac
+    done
+}
+
+parse_args "$@"
+if [[ $SHOW_HELP -eq 1 ]]; then
+    print_help; exit 0
 fi
 
-# Rename old htaccess for bkp
-HTACCESS_FILE=".htaccess"
-NEW_HTACCESS_FILE="${HTACCESS_FILE}_"
-COUNTER=1
+# Configuration modifiable
+# Si vous voulez que les extensions listées soient activées automatiquement,
+# mettez ENABLE_EXT=1 (attention : seules les extensions présentes sur le système
+# seront prises en compte). Par défaut on laisse les extensions commentées.
+ENABLE_EXT=0
+DEFAULT_MEMORY_LIMIT="2048M"
 
-while [[ -f "$NEW_HTACCESS_FILE" ]]; do
-    NEW_HTACCESS_FILE="${HTACCESS_FILE}_$COUNTER"
-    COUNTER=$((COUNTER + 1))
-done
+mktemp_portable() {
+    # Fonction utilitaire : mktemp portable
+    # Pourquoi : la syntaxe de mktemp diffère entre GNU (Linux) et BSD (macOS). Cette
+    # fonction essaye plusieurs variantes afin d'obtenir un fichier temporaire
+    # utilisable sur la plupart des systèmes sans provoquer d'erreur.
+    # On retourne un chemin (stdout) utilisable pour l'écriture atomique.
+    # Exemple d'utilisation : TMP=$(mktemp_portable "${HTACCESS_FILE}.tmp")
+    # Le fichier retourné doit être supprimé après usage ; on gère ça via trap.
+    local prefix="$1"
+    local tmp
+    if tmp=$(mktemp "${prefix}.XXXX" 2>/dev/null); then
+        echo "$tmp"; return 0
+    fi
+    if tmp=$(mktemp -t "${prefix}" 2>/dev/null); then
+        echo "$tmp"; return 0
+    fi
+    if tmp=$(mktemp 2>/dev/null); then
+        echo "$tmp"; return 0
+    fi
+    # Last resort
+    echo "/tmp/${prefix}.$RANDOM"
+}
 
-if [[ -f "$HTACCESS_FILE" ]]; then
-    mv "$HTACCESS_FILE" "$NEW_HTACCESS_FILE"
-    echo -e "$TXT_OK Ancien fichier rename en $NEW_HTACCESS_FILE."
+# Sélection de la version PHP
+# On supporte trois modes d'entrée :
+# 1) Argument CLI (-v/--version) : utile pour automatisation/CI
+# 2) Variable d'environnement exportée PHP_VERSION : utile pour scripts appelants
+# 3) Prompt interactif : quand l'utilisateur lance manuellement le script
+#
+# On accepte également le format "7.4" qui est normalisé en "74".
+if [[ -n "$CLI_VERSION" ]]; then
+    PHP_VERSION="$CLI_VERSION"
+elif [[ -n "${PHP_VERSION:-}" ]]; then
+    # keep already-exported PHP_VERSION
+    :
 else
-    echo -e "$TXT_OK Aucun fichier $HTACCESS_FILE à renommer."
+    while true; do
+        echo -e "$TXT_INFO Sélectionnez la version de PHP au format 74 pour PHP 7.4 (ex: 7.4 ou 74) :"
+        read -r PHP_VERSION
+
+        # Normaliser 7.4 -> 74
+        if [[ $PHP_VERSION =~ ^[0-9]+\.[0-9]+$ ]]; then
+            PHP_VERSION="${PHP_VERSION/./}"
+        fi
+
+        if [[ $PHP_VERSION =~ ^(52|53|54|55|56|70|71|72|73|74|75|76|77|78|79|80|81|82|83)$ ]]; then
+            break
+        fi
+
+        echo -e "$TXT_ERROR La version de PHP saisie '$PHP_VERSION' n'est pas correcte. Réessayez."
+    done
 fi
 
-# Créer le nouveau .htaccess
+# Sauvegarde de l'ancien .htaccess (backup horodaté)
+# Pourquoi : les règles .htaccess peuvent rendre un site inaccessible. Nous
+# sauvegardons l'ancien fichier avec un timestamp pour pouvoir revenir en arrière
+# rapidement si nécessaire.
+HTACCESS_FILE=".htaccess"
+TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+if [[ -f "$HTACCESS_FILE" ]]; then
+    NEW_HTACCESS_FILE="${HTACCESS_FILE}.bak.$TIMESTAMP"
+    # Si le fichier existe déjà (cas improbable), ajouter un suffixe numérique
+    local_counter=1
+    while [[ -f "$NEW_HTACCESS_FILE" ]]; do
+        NEW_HTACCESS_FILE="${HTACCESS_FILE}.bak.${TIMESTAMP}.$local_counter"
+        local_counter=$((local_counter + 1))
+    done
+    if [[ $DRY_RUN -eq 1 ]]; then
+        echo -e "$TXT_INFO [dry-run] Ancien fichier serait renommé en ${NEW_HTACCESS_FILE}."
+    else
+        mv "${HTACCESS_FILE}" "${NEW_HTACCESS_FILE}"
+        echo -e "$TXT_OK Ancien fichier renommé en ${NEW_HTACCESS_FILE}."
+    fi
+else
+    echo -e "$TXT_INFO Aucun fichier ${HTACCESS_FILE} à renommer."
+fi
+
+# Construire le bloc .htaccess
 BLOCK_TEMPLATE=$(cat <<EOL
 <FilesMatch \\.php$>
-SetHandler application/x-httpd-php$PHP_VERSION
+SetHandler application/x-httpd-php${PHP_VERSION}
 </FilesMatch>
-AddHandler application/x-httpd-php$PHP_VERSION .php
-suPHP_ConfigPath $PWD/php.ini
+AddHandler application/x-httpd-php${PHP_VERSION} .php
+suPHP_ConfigPath ${PWD}/php.ini
 EOL
 )
 
-# Créer le htaccess avec les règles
-echo "$BLOCK_TEMPLATE" > "$HTACCESS_FILE"
-echo -e "$TXT_OK Nouveau fichier $HTACCESS_FILE créé."
+# Écriture atomique du .htaccess
+# On écrit d'abord dans un fichier temporaire (mktemp_portable) puis on effectue un
+# mv atomique. Cela évite d'avoir un fichier .htaccess partiellement écrit si le
+# script est interrompu. Un trap supprime le temporaire en cas d'erreur.
+TMP_HTACCESS="$(mktemp_portable "${HTACCESS_FILE}.tmp")"
+trap '[[ -n "${TMP_HTACCESS:-}" && -f "${TMP_HTACCESS}" ]] && rm -f -- "${TMP_HTACCESS}"' EXIT
+if [[ $DRY_RUN -eq 1 ]]; then
+    echo -e "$TXT_INFO [dry-run] Ecriture du .htaccess (contenu affiché ci-dessous):"
+    printf "%s\n" "$BLOCK_TEMPLATE"
+else
+    printf "%s\n" "$BLOCK_TEMPLATE" > "$TMP_HTACCESS"
+fi
 
-# Ajout des Rewrite de Wordpress
+# Ajout des Rewrite de WordPress si présent
 if [[ -f "wp-config.php" ]]; then
-    echo -e "$TXT_INFO Site Wordpress trouvé. Ajout des règles dans le .htaccess."
-
-    # Ajouter les règles
-    cat <<EOL >> "$HTACCESS_FILE"
+    echo -e "$TXT_INFO Site WordPress trouvé. Ajout des règles dans le .htaccess."
+    if [[ $DRY_RUN -eq 1 ]]; then
+        cat <<EOL
 
 # BEGIN WordPress
 RewriteEngine On
@@ -65,53 +183,129 @@ RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule . /index.php [L]
 # END WordPress
 EOL
-    echo -e "$TXT_OK Règles ajoutées dans le $HTACCESS_FILE."
+    else
+        cat <<EOL >> "$TMP_HTACCESS"
+
+# BEGIN WordPress
+RewriteEngine On
+RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+RewriteBase /
+RewriteRule ^index\.php$ - [L]
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule . /index.php [L]
+# END WordPress
+EOL
+    fi
+
+# BEGIN WordPress
+RewriteEngine On
+RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+RewriteBase /
+RewriteRule ^index\.php$ - [L]
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule . /index.php [L]
+# END WordPress
+EOL
+    echo -e "$TXT_OK Règles WordPress ajoutées au fichier temporaire."
 else
-    echo -e "$TXT_INFO Pas de Wordpress trouvé. Uniquement les règles PHP seront ajoutées."
+    echo -e "$TXT_INFO Pas de WordPress détecté. Seules les règles PHP seront ajoutées."
 fi
 
-# Créer php.ini
+# Déplacer atomiquement
+if [[ $DRY_RUN -eq 1 ]]; then
+    echo -e "$TXT_INFO [dry-run] .htaccess prêt à être déplacé en ${HTACCESS_FILE} (non écrit)."
+    # montrer un aperçu
+    echo "--- .htaccess preview ---"
+    echo "$BLOCK_TEMPLATE"
+else
+    mv "$TMP_HTACCESS" "$HTACCESS_FILE"
+    trap - EXIT
+    echo -e "$TXT_OK Nouveau fichier ${HTACCESS_FILE} créé."
+fi
+
+# Génération du php.ini
+# On génère un php.ini minimal avec des valeurs courantes. Les extensions sont
+# commentées par défaut pour éviter d'activer des modules inexistants sur la
+# machine cible (ce qui provoquerait des erreurs à l'initialisation de PHP).
 PHP_INI_FILE="php.ini"
+if [[ $DRY_RUN -eq 1 ]]; then
+    echo -e "$TXT_INFO [dry-run] Le fichier ${PHP_INI_FILE} serait créé avec le contenu suivant:"
+    cat <<EOL
+; Generated by prestashop-fix.sh
+date.timezone = Europe/Paris
 
-# Création du fichier php.ini avec les infos natives.
-cat <<EOL > "$PHP_INI_FILE"
-date.timezone=Europe/Paris
-extension=mysqlnd.so
-extension=nd_mysqli.so
-extension=nd_pdo_mysql.so
-extension=json.so
-extension=intl.so
-extension=mcrypt.so
-extension=gd.so
-extension=xml.so
-extension=xmlreader.so
-extension=xmlrpc.so
-extension=xmlwriter.so
-extension=soap.so
-extension=tidy.so
-extension=bcmath.so
-extension=dom.so
-extension=fileinfo.so
-extension=imap.so
-extension=zip.so
-extension=mcrypt.so
-extension=intl.so
-extension=pdo.so
-extension=fileinfo.so
-extension=mbstring.so
-extension=imagick.so
-display_errors=off
-memory_limit=2038M
-max_input_vars=250000
-max_execution_time=360
-output_buffering=4096
-upload_max_filesize=512M
-post_max_size=512M
+; Performances / limites
+display_errors = Off
+memory_limit = ${DEFAULT_MEMORY_LIMIT}
+max_input_vars = 250000
+max_execution_time = 360
+output_buffering = 4096
+upload_max_filesize = 512M
+post_max_size = 512M
+
+; Extensions: décommentez celles que vous voulez activer si elles existent sur le système
+;extension=mysqli.so
+;extension=pdo_mysql.so
+;extension=json.so
+;extension=intl.so
+;extension=gd.so
+;extension=xml.so
+;extension=xmlreader.so
+;extension=xmlwriter.so
+;extension=soap.so
+;extension=tidy.so
+;extension=bcmath.so
+;extension=dom.so
+;extension=fileinfo.so
+;extension=imap.so
+;extension=zip.so
+;extension=mbstring.so
+;extension=imagick.so
+
 EOL
+else
+    cat <<EOL > "$PHP_INI_FILE"
+; Generated by prestashop-fix.sh
+date.timezone = Europe/Paris
 
-echo -e "$TXT_OK Le $PHP_INI_FILE est bien créé avec les options."
+; Performances / limites
+display_errors = Off
+memory_limit = ${DEFAULT_MEMORY_LIMIT}
+max_input_vars = 250000
+max_execution_time = 360
+output_buffering = 4096
+upload_max_filesize = 512M
+post_max_size = 512M
 
-# Fin
+; Extensions: décommentez celles que vous voulez activer si elles existent sur le système
+;extension=mysqli.so
+;extension=pdo_mysql.so
+;extension=json.so
+;extension=intl.so
+;extension=gd.so
+;extension=xml.so
+;extension=xmlreader.so
+;extension=xmlwriter.so
+;extension=soap.so
+;extension=tidy.so
+;extension=bcmath.so
+;extension=dom.so
+;extension=fileinfo.so
+;extension=imap.so
+;extension=zip.so
+;extension=mbstring.so
+;extension=imagick.so
+
+EOL
+    echo -e "$TXT_OK Le ${PHP_INI_FILE} a été créé (extensions commentées par défaut)."
+fi
+
+# Nettoyage optionnel
+if [[ -f "phpver.sh" ]]; then
+    rm -f "phpver.sh"
+    echo -e "$TXT_INFO Fichier phpver.sh supprimé."
+fi
+
 echo -e "\n$TXT_OK Script terminé avec succès !"
-
-rm -rf phpver.sh


### PR DESCRIPTION
# 🛠️ prestashop-fix.sh — Description étendue

## 📌 But du script
Ce script automatise la génération / mise à jour d'un fichier `.htaccess` et la création d'un `php.ini` pour des sites PHP (WordPress / PrestaShop). Il vise à offrir :
- une méthode sûre et atomique d'écriture du `.htaccess`,
- une sauvegarde automatique de l'ancien `.htaccess`,
- une génération d'un `php.ini` minimal et réutilisable,
- une ergonomie CLI (mode non interactif possible, dry-run).

Il a été adapté pour être plus portable (Linux/macOS/BSD) et plus sûr en production.

---

## 🧭 Principales améliorations apportées
- 🔐 Robustesse : `set -euo pipefail` + `IFS` restreint pour éviter des comportements imprévus liés aux erreurs ou aux variables non définies.  
- 🪪 Sauvegarde : l'ancien `.htaccess` est renommé en `.htaccess.bak.<timestamp>` avant toute écriture.  
- 🔁 Écriture atomique : on écrit d'abord dans un fichier temporaire (fonction `mktemp_portable`) puis on remplace `.htaccess` par un `mv` atomique — minimise le risque d'état incomplet.  
- ♻️ Portabilité : `mktemp_portable()` prend en charge les différences de comportement de `mktemp` entre GNU et BSD (macOS).  
- 🧭 Entrée PHP flexible : accepte `7.4` ou `74` et normalise vers `74`. Validation stricte des versions prises en charge.  
- 🧰 CLI et automatisation :
  - `-n`, `--dry-run` : simulation sans écrire ;
  - `-v`, `--version <ver>` : fournir la version PHP en non interactif ;
  - `-h`, `--help` : aide.  
- ⚠️ Sécurité du php.ini : le `php.ini` est généré avec les extensions commentées par défaut pour éviter d'activer des modules inexistants qui provoqueraient des erreurs au démarrage.  
- 🧹 Nettoyage : suppression conditionnelle de `phpver.sh` (si présent).

---

## 📂 Contenu produit
- `.htaccess` : contient
  - directives `SetHandler` / `AddHandler` pour sélectionner la version PHP (p.ex. `application/x-httpd-php74`),
  - directive `suPHP_ConfigPath /chemin/absolu/php.ini`,
  - blocs WordPress standard (si `wp-config.php` est détecté).
- `php.ini` : fichier minimal contenant timezone, limites, et une liste d'extensions commentées.

---

## ⚙️ Détail technique (section par section)

### 1. En-tête et sécurité
- `set -euo pipefail` : coupe le script à la moindre erreur, empêche l'utilisation de variables non initialisées et fait échouer les pipelines si une commande échoue.  
- `IFS=$'\n\t'` : évite que les espaces cassent les boucles/reads.

### 2. mktemp_portable()
- Permet d'obtenir un fichier temporaire portable :
  - teste `mktemp "${prefix}.XXXX"` (GNU),
  - puis `mktemp -t "${prefix}"` (BSD/macOS),
  - puis `mktemp` (fallback),
  - enfin `/tmp/<prefix>.$RANDOM` en dernier recours.  
- Utilisé pour écrire atomiquement le `.htaccess`.

### 3. Sélection de la version PHP
- Modes acceptés :
  - CLI (`-v 74`) ;
  - variable d'environnement exportée `PHP_VERSION=74` ;
  - saisie interactive.  
- Acceptation des formats `7.4` et `74` (normalisation automatique).  
- Validation stricte : seules certaines versions (52..56, 70..83) sont acceptées — modifiable dans le script.

### 4. Backup .htaccess
- Avant toute modification, si `.htaccess` existe, on le renomme en `.htaccess.bak.<YYYYMMDD-HHMMSS>` ; si le nom existe déjà on ajoute un suffixe numérique.  
- En `--dry-run` on affiche l'action sans renommer.

### 5. Écriture atomique du .htaccess
- Contenu principal écrit dans un fichier temporaire.  
- Ajout optionnel des règles WordPress si `wp-config.php` est détecté.  
- `mv <tmp> .htaccess` pour remplacement atomique.  
- `trap` mis en place pour supprimer le tmp si le script est interrompu.

### 6. php.ini
- Généré avec valeurs par défaut :
  - timezone = Europe/Paris
  - memory_limit = 2048M (modifiable via variable)
  - autres limites (upload, post_max_size, etc.)  
- Les extensions sont commentées pour éviter des erreurs si elles sont absentes.  
- En `--dry-run` le contenu est affiché sans écrire.

### 7. Options CLI
- `-n, --dry-run` : simule tout, n'écrit rien.  
- `-v, --version <ver>` : version PHP en ligne de commande.  
- `-h, --help` : affiche l'aide.  
- Comportement non interactif possible via `-v` ou `PHP_VERSION=74`.

---

## 🧪 Exemples d'utilisation

- Mode interactif (avec prompt) :
```bash
./prestashop-fix.sh
```

- Mode non interactif (version fournie) :
```bash
./prestashop-fix.sh -v 74
# ou
PHP_VERSION=74 ./prestashop-fix.sh
```

- Dry-run (vérifier avant d'écrire) :
```bash
./prestashop-fix.sh -n -v 74
```

---

## ✅ Vérifications effectuées (par l'auteur du patch)
- Vérification de syntaxe : `bash -n prestashop-fix.sh` → OK.  
- Test d'exécution dans un répertoire temporaire :
  - Exécution réelle (sans dry-run) dans `/tmp/prestashop-fix-test` : `.htaccess` et `php.ini` créés correctement.  
  - Dry-run testé : affiche les actions sans écrire.  
- Test sur macOS : compatibilité `mktemp_portable` prévue ; attention aux outils système (ex. git peut demander d'accepter la licence Xcode).

---

## ⚠️ Points d'attention / risques
- La directive `SetHandler application/x-httpd-php<version>` dépend de la configuration de l'hébergeur. Certains hébergeurs utilisent des syntaxes différentes. Vérifier avec l'hébergeur cible.  
- Le `suPHP_ConfigPath` doit pointer vers un chemin valide. Le script écrit le chemin absolu basé sur le `pwd`. Si ton chemin contient des espaces ou caractères spéciaux, vérifie la compatibilité avec l'hébergeur.  
- `php.ini` contient des extensions commentées : si tu décommente une extension qui n'existe pas sur le système, PHP peut émettre des erreurs au démarrage.  
- Valeurs fortes (ex. `memory_limit=2048M`) peuvent ne pas être autorisées en mutualisé : adapte-les si nécessaire.  
- Sur macOS, certaines commandes utilisateur (ex. `git`) peuvent demander l’acceptation de la licence Xcode. Le commit Git peut être bloqué jusqu'à acceptation (`sudo xcodebuild -license`).

---

## 🛠️ Bonnes pratiques recommandées
- Toujours exécuter d'abord en `--dry-run` sur un environnement de test.  
- S'assurer d'avoir une sauvegarde du site ou snapshot avant modification en production.  
- Vérifier la compatibilité des directives `.htaccess` avec l'hébergeur (ex: OVH, cPanel, Apache custom).  
- Personnaliser `php.ini` en fonction de l'environnement (ex. baisser memory_limit en mutualisé).

---

## 🧾 Changelog (résumé des commits récents)
- Ajout de commentaires explicatifs en français dans le script.  
- Ajout `mktemp_portable()`.  
- Ajout des options CLI (`--dry-run`, `-v/--version`, `--help`).  
- Backup horodaté et écriture atomique du `.htaccess`.  
- Génération de `php.ini` avec extensions commentées.

---

## 🔁 Flux recommandé pour contribution (fork & PR)
1. Fork du dépôt.  
2. Créer une branche feature/nom (ex. `feature/portability-dryrun`).  
3. Appliquer modifications et tester localement :
   - `bash -n prestashop-fix.sh`
   - `PHP_VERSION=74 ./prestashop-fix.sh -n`  
4. Commit et push vers ton fork.  
5. Ouvrir une Pull Request vers la branche principale du repo source avec une description claire.  
6. Dans la PR, indiquer si tu veux une revue ou un merge automatisé.

---
